### PR TITLE
Test pre release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,7 @@ workflows:
       - build_and_deploy:
           context:
             - GITHUB
-            - NPM
-          filters:
-            branches:
-              only:
-              - master
-  build_only:
-    jobs:
-      - build_only:
-          context:
-            - GITHUB
-          filters:
-            branches:
-              ignore:
-              - master
+            - NPM          
 jobs:
   build_and_deploy:
     working_directory: ~/package
@@ -32,14 +19,3 @@ jobs:
             yarn
             yarn test
             yarn release
-  build_only:
-    working_directory: ~/package
-    docker:
-      - image: circleci/node:10
-    steps:
-      - checkout
-      - run:
-          name: Compile and Run Tests
-          command: |
-            yarn
-            yarn test

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -27,7 +27,8 @@ module.exports = {
          */
         'next',
         /**
-         * Pre-releases are published for testing and preview purposes.
+         * Pre-releases are published for testing and preview purposes. Any branch that doesn't match
+         * a support, master or next branch will be released as a pre-release branch.
          * 
          * Pre-release versions take the form M.N.P-<branch>.X where 
          *  - M, N and P are the major, minor and patch number of the semver that will be published 

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -43,7 +43,7 @@ module.exports = {
             /**
              * pre-release as vX.X.X-beta.N from the last version tag in branch's commit history
              */
-            name: '.*', 
+            name: '*', 
             prerelease: true
         }],
     plugins: [

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -27,8 +27,7 @@ module.exports = {
          */
         'next',
         /**
-         * Pre-releases are published for testing and preview purposes. Any branch that doesn't match
-         * a support, master or next branch will be released as a pre-release branch.
+         * Pre-releases are published for testing and preview purposes.
          * 
          * Pre-release versions take the form M.N.P-<branch>.X where 
          *  - M, N and P are the major, minor and patch number of the semver that will be published 
@@ -41,9 +40,9 @@ module.exports = {
          */
         {
             /**
-             * pre-release as vX.X.X-beta.N from the last version tag in branch's commit history
+             * pre-release as vX.X.X-<branch>.N from the last version tag in branch's commit history
              */
-            name: '*', 
+            name: '**', 
             prerelease: true
         }],
     plugins: [

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,10 +1,75 @@
 module.exports = {
+    branches: [
+        /**
+         * Support releases allowing for fixes and features to non-latest versions.
+         * 
+         * To support a previous verison, create a branch from the previous version tag
+         * and name it M.x or M.x.x or M.N.x where M and N are major and minor versions you are
+         * supporting, respectively. 
+         * 
+         * E.g. If you are supporting version 1.2 specifically, then name the branch '1.2.x' 
+         * (literally, with the x).
+         */
+        '+([0-9])?(.{+([0-9]),x}).x', 
+        /**
+         * Regular releases to default @latest channel ('yarn add package' will install it)
+         */
+        'master', 
+        /**
+         * Early releases to a @next channel, meant as release candidates or optional upgrades.
+         * 
+         * Early releases won't be installed with `yarn add <pkg>`, unless the version or tag is
+         * explicitly specified. So, `yarn add <pkg>:next` will.
+         * 
+         * These are versions ready to be consumed, but are held back from being the default (@latest) 
+         * version. This might be used when there is an adoption timeline for the new version, 
+         * during which using the new version is optional, or in an RFC (Request for Comments).
+         */
+        'next',
+        /**
+         * Pre-releases are published for testing and preview purposes.
+         * 
+         * Pre-release versions take the form M.N.P-<branch>.X where 
+         *  - M, N and P are the major, minor and patch number of the semver that will be published 
+         *    upon on completion, 
+         *  - <branch> is the name of the branch on which development is taking place, and 
+         *  - X is the revision number.
+         * 
+         * Pre-releases won't be installed with `yarn add <pkg>`, unless the version or tag is
+         * explicitly specified. So, `yarn add <pkg>:v3.2.1-branch.1` will.
+         */
+        {
+            /**
+             * pre-release as vX.X.X-beta.N from the last version tag in branch's commit history
+             */
+            name: '.*', 
+            prerelease: true
+        }],
     plugins: [
+        /**
+         * Reads and inspects commits since the last released version for conventional commit messages.
+         */
         "@semantic-release/commit-analyzer",
-        "@semantic-release/release-notes-generator",        
-        "@semantic-release/changelog",
+        /**
+         * Interprets and assembles the conventional commit messages for use in later steps, and determines
+         * the next semver for release.
+         */
+        "@semantic-release/release-notes-generator",
+        /**
+         * Patches package.json with the new semver, and publishes the package to NPM.
+         */
         "@semantic-release/npm",
+        /**
+         * Pushes the release and its release notes to its GitHub repository. 
+         */
         "@semantic-release/github",
+        /**
+         * Inserts the latest release notes into CHANGELOG.md
+         */
+        "@semantic-release/changelog",
+        /**
+         * Commits and pushes the updated package.json and CHANGELOG.md to origin.
+         */
         ["@semantic-release/git", {
             "assets": ["package.json", "CHANGELOG.md"],
             "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -16,7 +16,7 @@ module.exports = {
          */
         'master', 
         /**
-         * Early releases to a @next channel, meant as release candidates or optional upgrades.
+         * Early releases to a @next channel, meant as stable release candidates or optional upgrades.
          * 
          * Early releases won't be installed with `yarn add <pkg>`, unless the version or tag is
          * explicitly specified. So, `yarn add <pkg>:next` will.
@@ -27,7 +27,7 @@ module.exports = {
          */
         'next',
         /**
-         * Pre-releases are published for testing and preview purposes.
+         * Pre-releases are unstable and published for testing and preview purposes.
          * 
          * Pre-release versions take the form M.N.P-<branch>.X where 
          *  - M, N and P are the major, minor and patch number of the semver that will be published 
@@ -42,7 +42,7 @@ module.exports = {
             /**
              * pre-release as vX.X.X-<branch>.N from the last version tag in branch's commit history
              */
-            name: '**', 
+            name: '*',
             prerelease: true
         }],
     plugins: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [3.1.0-test-pre-release.1](https://github.com/tibbercom/tibber-express-utils/compare/v3.0.0...v3.1.0-test-pre-release.1) (2020-12-18)
+
+
+### Bug Fixes
+
+* fix pre-release glob ([754648b](https://github.com/tibbercom/tibber-express-utils/commit/754648bbd3c5febe33264a91269c6ac4153c324a))
+
+
+### Features
+
+* add a fake feature for testing pre-releases ([e8714d9](https://github.com/tibbercom/tibber-express-utils/commit/e8714d97bd5752d9cff0a7fe93515572b4774d31))
+
 # [3.0.0](https://github.com/tibbercom/tibber-express-utils/compare/v2.1.0...v3.0.0) (2020-12-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tibber-express-utils",
-  "version": "3.0.0",
+  "version": "3.1.0-test-pre-release.1",
   "description": "",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,7 @@ export * from './jsonRouting';
 export * from './jsonMiddleware';
 export * as Errors from './errors';
 export * from './types';
+
+/**
+ * Adding a fake feature to test a pre-release.
+ */

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,3 @@ export * from './jsonRouting';
 export * from './jsonMiddleware';
 export * as Errors from './errors';
 export * from './types';
-
-/**
- * Adding a fake feature to test a pre-release.
- */


### PR DESCRIPTION
Configures and tests a `semantic-release` and `circleci` configuration that publishes pre-release packages to NPM from branches that aren't <support>, master or next. Pre-release channels are named after the branch they are released from.

In order to publish a pre-release package, ensure you branch name conforms to semver guidelines, and consists of only numbers, alphanumeric characters and dashes (-).

If the repository contains single-word branches that contain invalid characters, semantic-release will fail even if they are not the branch currently being released. This is a known issue: https://github.com/semantic-release/semantic-release/issues/1717 