### PR TITLE
fix(release): publish to npm via CircleCI OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,14 @@ workflows:
       - build_and_deploy:
           context:
             - GITHUB
-            - NPM
 jobs:
   build_and_deploy:
     working_directory: ~/package
     docker:
-      - image: cimg/node:lts
+      # cimg/node:24.18.0 ships npm 11.16.0; CircleCI OIDC trusted
+      # publishing requires npm >= 11.11.0 (same pattern as tibber-aws /
+      # tibber-dsf / tibber-httpclient).
+      - image: cimg/node:24.18.0
     steps:
       - checkout
       - run:
@@ -18,4 +20,24 @@ jobs:
           command: |
             yarn
             yarn test
+            # semantic-release computes the version from commits, pushes the
+            # version-bump commit + tag, and creates the GitHub release. It
+            # no-ops on PR builds and non-release branches. npmPublish is off
+            # in .releaserc.js; the registry publish happens below via OIDC
+            # trusted publishing (no stored npm token, nothing for 2FA to
+            # block).
             yarn release
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+              echo "not master — skipping npm publish"
+              exit 0
+            fi
+            V=$(node -p "require('./package.json').version")
+            if npm view "tibber-express-utils@$V" version >/dev/null 2>&1; then
+              echo "tibber-express-utils@$V already published, skipping"
+              exit 0
+            fi
+            NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            export NPM_ID_TOKEN
+            # Provenance is emitted automatically under trusted publishing —
+            # no --provenance flag needed.
+            npm publish

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -64,9 +64,12 @@ module.exports = {
          */
         "@semantic-release/release-notes-generator",
         /**
-         * Patches package.json with the new semver, and publishes the package to NPM.
+         * Patches package.json with the new semver. Publishing is done by the
+         * CI job itself via CircleCI OIDC trusted publishing (npm >= 11.11,
+         * no stored token) — with npmPublish off, this plugin also skips its
+         * NPM_TOKEN verification.
          */
-        "@semantic-release/npm",
+        ["@semantic-release/npm", { "npmPublish": false }],
         /**
          * Pushes the release and its release notes to its GitHub repository. 
          */

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,9 @@ title to `fix(deps): …` if consumers should get the bump.
 
 **If the publish step fails** after semantic-release has pushed the version
 bump: just rerun the job — the already-published guard sees the committed
-version is missing from npm and publishes it. (Versions 4.0.14–4.0.18 were
+version is missing from npm and publishes it. Note this self-heal applies to
+*any* master build, release or not: while the committed version is missing
+from npm, the next merge of any kind publishes it. (Versions 4.0.14–4.0.18 were
 tagged during the broken-token era but never reached npm; consumers jump
 from 4.0.13 straight to the first post-fix release.)
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,28 @@
 # Usage
 
+## Releases & publishing — read before merging a PR
+
+Merging to `master` runs the CircleCI `build_and_deploy` job:
+[semantic-release](https://semantic-release.gitbook.io/) computes the version
+from the squash-commit title (conventional commits: `fix:` → patch, `feat:` →
+minor, `feat!:`/`BREAKING CHANGE` → major; `chore:`/`docs:`/plain titles →
+**no release**), pushes the version-bump commit + tag, creates the GitHub
+release, and the job then publishes to npm via
+[trusted publishing](https://docs.npmjs.com/trusted-publishers) (CircleCI
+OIDC — no stored npm token; requires this package's npmjs trusted-publisher
+entry and npm ≥ 11.11, i.e. the `cimg/node:24` image).
+
+**Dep-update PRs**: Dependabot's `fix(deps): …` titles trigger a patch
+release on merge. A tool that squashes with a plain title (e.g. Renovate's
+default `Update dependency x to vY`) will NOT publish — edit the squash
+title to `fix(deps): …` if consumers should get the bump.
+
+**If the publish step fails** after semantic-release has pushed the version
+bump: just rerun the job — the already-published guard sees the committed
+version is missing from npm and publishes it. (Versions 4.0.14–4.0.18 were
+tagged during the broken-token era but never reached npm; consumers jump
+from 4.0.13 straight to the first post-fix release.)
+
 ## Requirements
 
 - **Node.js**: 18 or higher


### PR DESCRIPTION
Same disease as tibber-aws (#596 there), slightly different symptom: the `NPM_TOKEN` publish gets npm's 2FA/OTP challenge (`EOTP`), but since this repo's master has no push-blocking rules, semantic-release's git plugin kept working — so **4.0.14–4.0.18 are ghost versions**: version-bumped and tagged in git, never published to npm (npm's latest is 4.0.13 from 2026-05-12).

Adopts the OIDC trusted-publishing pattern proven in tibber-aws / tibber-dsf / tibber-httpclient, adapted to this repo:

- **`.releaserc.js`** → `npmPublish: false`: semantic-release keeps everything that works here (version calc, version-bump push, tag, GitHub release); the job owns the registry publish. Token verification is skipped.
- **CI job** → `cimg/node:24.18.0` (npm ≥ 11.11 for CircleCI OIDC), `NPM` context dropped, publish via `circleci run oidc get` → `npm publish` (provenance automatic).
- **Guards**: master-only (this single job also runs on PR branches — semantic-release no-ops there but the publish must too) + already-published check, which doubles as self-healing: if a publish fails after the version bump landed, a plain rerun publishes the committed version.
- **readme**: releases & publishing section with squash-title rules and dep-update merge instructions (Dependabot's `fix(deps):` titles already release here).

npmjs trusted-publisher entry for this package is configured (confirmed). Merging this PR as `fix:` cuts the next release — consumers jump 4.0.13 → 4.0.19 (the ghosts stay unpublished; their content is included).

https://claude.ai/code/session_01XPpWb2oUfp33xjDQM4Rd3w